### PR TITLE
Windows os cmd use double quotes

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -19,7 +19,7 @@ async function install ( file: vscode.Uri ) {
   await term.processId;
   await Utils.delay ( 200 );
 
-  term.sendText ( `${command} --install-extension '${file.fsPath}'` );
+  term.sendText ( `${command} --install-extension "${file.fsPath}"` );
   term.sendText ( `echo 'Installation ended'` );
 
   term.show ( false );


### PR DESCRIPTION
Fixes #5

I have tested it with path containing `$1`. It worked. 

Probably shouldn't break anything on Linux/Mac but I didn't test that.